### PR TITLE
support for spacy3

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -22,6 +22,7 @@ Encoding: UTF-8
 LazyData: true
 Imports: 
     reticulate (>= 1.19),
+    renv (>= 0.16),
     data.table,
     assertthat,
     rappdirs,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -23,6 +23,7 @@ LazyData: true
 Imports: 
     reticulate (>= 1.19),
     renv (>= 0.16),
+    cli (>= 3.4.0),
     data.table,
     assertthat,
     rappdirs,

--- a/inst/environment.yml
+++ b/inst/environment.yml
@@ -1,0 +1,20 @@
+name: clinspacy 
+channels:
+  - conda-forge
+  - defaults
+variables:
+   CFLAGS: "-mavx -DWARN(a)=(a)"
+dependencies:
+  - python=3.10
+  - Cython
+  - pip
+  - pip:
+      - git+https://github.com/jianlins/PyRuSH.git@master
+      - spacy==3.4.1
+      - medspacy==1.0.0
+      - medspacy-quickumls==2.6
+      - scispacy==0.5.1
+      - en-core-sci-lg @ https://s3-us-west-2.amazonaws.com/ai2-s2-scispacy/releases/v0.5.1/en_core_sci_lg-0.5.1.tar.gz
+  - setuptools>=65.5.0
+  - spacy-loggers=1.0.3
+  - scikit-learn=1.1.3

--- a/inst/requirements.txt
+++ b/inst/requirements.txt
@@ -1,10 +1,13 @@
-Cython
-git+https://github.com/jianlins/PyRuSH.git@master
+Cython>=0.29.32
 setuptools>=65.5.0
+numpy
+spacy==3.4.1
+# git+https://github.com/jianlins/quicksectx@0.3.3
+PyRuSH @ git+https://github.com/DSLituiev/PyRuSH.git@master
 medspacy==1.0.0
 medspacy-quickumls==2.6
 scispacy==0.5.1
-spacy==3.4.1
 spacy-legacy==3.0.10
 spacy-loggers==1.0.3
+scikit-learn==1.1.3
 en-core-sci-lg @ https://s3-us-west-2.amazonaws.com/ai2-s2-scispacy/releases/v0.5.1/en_core_sci_lg-0.5.1.tar.gz

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,10 @@
+Cython
+git+https://github.com/jianlins/PyRuSH.git@master
+setuptools>=65.5.0
+medspacy==1.0.0
+medspacy-quickumls==2.6
+scispacy==0.5.1
+spacy==3.4.1
+spacy-legacy==3.0.10
+spacy-loggers==1.0.3
+en-core-sci-lg @ https://s3-us-west-2.amazonaws.com/ai2-s2-scispacy/releases/v0.5.1/en_core_sci_lg-0.5.1.tar.gz


### PR DESCRIPTION
This pull request provides:
1. support for spacy3
2. keeps python versions in `requirements.txt`, not within R code, by leveraging `renv` package
3. compatibility with spacy2 is retained, though current `requirements.txt` points to spacy3 compatible versions only